### PR TITLE
Fix org copilot export issue

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -66,7 +66,8 @@ KEY_PROPERTIES = {
     "workflow_run_jobs": ["id"],
     "artifacts": ["id"],
     # Copilot metrics are day-based and emitted per-user per-day.
-    "copilot_user_metrics_1_day": ["enterprise_slug", "day", "user_id"],
+    # Prevent organization and enterprise collisions by marking the scope.
+    "copilot_user_metrics_1_day": ["copilot_scope", "day", "user_id"],
 }
 
 VISITED_ORGS_IDS = set()
@@ -775,6 +776,7 @@ def get_copilot_user_metrics_1_day(schema, _repo_path, _state, mdata, _start_dat
 
 
                 record = {
+                    "copilot_scope": copilot_bookmark_key,
                     # enterprise_slug and enterprise_id are enterprise-specific and should remain null
                     # for organization-scoped Copilot runs.
                     "enterprise_slug": enterprise_slug,

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -66,7 +66,7 @@ KEY_PROPERTIES = {
     "workflow_run_jobs": ["id"],
     "artifacts": ["id"],
     # Copilot metrics are day-based and emitted per-user per-day.
-    # Prevent organization and enterprise collisions by marking the scope.
+    # Prevent organization and enterprise collisions by namespacing the scope.
     "copilot_user_metrics_1_day": ["copilot_scope", "day", "user_id"],
 }
 
@@ -776,7 +776,11 @@ def get_copilot_user_metrics_1_day(schema, _repo_path, _state, mdata, _start_dat
 
 
                 record = {
-                    "copilot_scope": copilot_bookmark_key,
+                    "copilot_scope": (
+                        f"enterprise:{enterprise_slug}"
+                        if enterprise_slug
+                        else f"organization:{organization}"
+                    ),
                     # enterprise_slug and enterprise_id are enterprise-specific and should remain null
                     # for organization-scoped Copilot runs.
                     "enterprise_slug": enterprise_slug,

--- a/tap_github/schemas/copilot_user_metrics_1_day.json
+++ b/tap_github/schemas/copilot_user_metrics_1_day.json
@@ -4,6 +4,11 @@
     "object"
   ],
   "properties": {
+    "copilot_scope": {
+      "type": [
+        "string"
+      ]
+    },
     "enterprise_slug": {
       "type": [
         "null",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the primary key for `copilot_user_metrics_1_day` and adds a required `copilot_scope` field, which can affect downstream deduplication and table definitions during syncs.
> 
> **Overview**
> Fixes Copilot org exports colliding with enterprise exports by **namespacing Copilot user-metrics records by scope**.
> 
> Updates `copilot_user_metrics_1_day` to emit a new `copilot_scope` field (e.g., `enterprise:<slug>` or `organization:<org>`) and switches the stream’s key properties from `enterprise_slug` to `copilot_scope` (along with `day` and `user_id`). The stream schema is extended to include `copilot_scope`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a652fbd7d1c76cdd3771aa8f65b1d16266b7a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->