### PR TITLE
Add cli properties

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -803,11 +803,13 @@ def get_copilot_user_metrics_1_day(schema, _repo_path, _state, mdata, _start_dat
                     "loc_deleted_sum": report_record.get("loc_deleted_sum"),
                     "used_agent": report_record.get("used_agent"),
                     "used_chat": report_record.get("used_chat"),
+                    "used_cli": report_record.get("used_cli"),
                     "totals_by_ide": report_record.get("totals_by_ide"),
                     "totals_by_feature": report_record.get("totals_by_feature"),
                     "totals_by_language_feature": report_record.get("totals_by_language_feature"),
                     "totals_by_language_model": report_record.get("totals_by_language_model"),
                     "totals_by_model_feature": report_record.get("totals_by_model_feature"),
+                    "totals_by_cli": report_record.get("totals_by_cli"),
                 }
                 add_insert_timestamp(record)
 

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -377,14 +377,14 @@ def authed_get(source, url, headers={}):
         resp = session.request(method="get", url=url, timeout=get_request_timeout())
         logger.info("Request received status code %s", resp.status_code)
         if resp.status_code != 200:
+            if source == COPILOT_USER_METRICS_STREAM and resp.status_code == 204:
+                timer.tags[metrics.Tag.http_status_code] = resp.status_code
+                return resp
             reset_time, remaining = get_reset_time_and_remaining_calls(
                 resp,
                 message=f"[Request Status {resp.status_code}] Reset time was going to be reached in"
                 + " {} seconds.  Remaining {} calls",
             )
-            if source == COPILOT_USER_METRICS_STREAM and resp.status_code == 204:
-                timer.tags[metrics.Tag.http_status_code] = resp.status_code
-                return resp
             # wait for limit to reset
             if resp.status_code == 403:
                 rate_throttling(resp)

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -382,6 +382,9 @@ def authed_get(source, url, headers={}):
                 message=f"[Request Status {resp.status_code}] Reset time was going to be reached in"
                 + " {} seconds.  Remaining {} calls",
             )
+            if source == COPILOT_USER_METRICS_STREAM and resp.status_code == 204:
+                timer.tags[metrics.Tag.http_status_code] = resp.status_code
+                return resp
             # wait for limit to reset
             if resp.status_code == 403:
                 rate_throttling(resp)
@@ -715,6 +718,14 @@ def get_copilot_user_metrics_1_day(schema, _repo_path, _state, mdata, _start_dat
                     message or "no details",
                 )
                 break
+
+            if response.status_code == 204:
+                logger.info(
+                    "Copilot report returned HTTP 204 (no content) for %s; skipping.",
+                    report_day,
+                )
+                current_day += timedelta(days=1)
+                continue
 
             # 404 is expected when a report isn't available yet; skip forward.
             if response.status_code == 404:

--- a/tap_github/schemas/copilot_user_metrics_1_day.json
+++ b/tap_github/schemas/copilot_user_metrics_1_day.json
@@ -94,6 +94,12 @@
         "boolean"
       ]
     },
+    "used_cli": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "totals_by_ide": {
       "type": [
         "null",
@@ -153,6 +159,12 @@
           "object"
         ]
       }
+    },
+    "totals_by_cli": {
+      "type": [
+        "null",
+        "object"
+      ]
     },
     "inserted_at": {
       "type": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new fields to the `copilot_user_metrics_1_day` schema and emitted records, which may require downstream schema updates. Also changes HTTP handling for Copilot endpoints to skip on `204`, altering control flow for missing-report days.
> 
> **Overview**
> Improves the `copilot_user_metrics_1_day` sync by **treating GitHub HTTP `204 No Content` as a skip** (both in `authed_get` and the day-by-day report loop) rather than raising an error.
> 
> Extends Copilot user metrics output/schema with **CLI-specific properties** (`used_cli` and `totals_by_cli`) so CLI usage is captured alongside existing IDE/feature aggregates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac22687d230d40a54bffa391cb9b9001601a26b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->