### PR TITLE
Exit stream when 502

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -258,6 +258,9 @@ def raise_for_error(resp, source, remaining):
         # don't raise a AuthException for 403 errors that are not rate limit related
         return None
 
+    if error_code == 502:
+        return None
+
     if 500 <= error_code < 600:
         raise RetriableServerError(resp.text)
 
@@ -686,6 +689,13 @@ def get_copilot_user_metrics_1_day(schema, _repo_path, _state, mdata, _start_dat
         extraction_time = singer.utils.now()
 
         if response.status_code != 200:
+            if response.status_code == 502:
+                logger.warning(
+                    "Copilot report metadata request for %s returned 502; stopping stream.",
+                    report_day,
+                )
+                return _state
+
             # 404 is expected when a report isn't available yet; skip forward.
             if response.status_code == 404:
                 message = None
@@ -2151,7 +2161,7 @@ def get_all_artifacts(schema, repo_path, state, mdata, start_date):
     with metrics.record_counter("artifacts") as counter:
         for response in authed_get_all_pages(
             "artifacts",
-            "https://api.github.com/repos/{}/actions/artifacts?page_len=100".format(repo_path),
+            "https://api.github.com/repos/{}/actions/artifacts?per_page=100".format(repo_path),
             artifacts_headers,
         ):
             artifacts = response.json()

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -397,6 +397,7 @@ def authed_get(source, url, headers={}):
                 rate_throttling(resp)
             # Copilot stream handles 502 itself (stops instead of retrying)
             if resp.status_code == 502 and source == COPILOT_USER_METRICS_STREAM:
+                timer.tags[metrics.Tag.http_status_code] = resp.status_code
                 return resp
             # retry
             raise_for_error(resp, source, remaining)

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -122,6 +122,10 @@ class RetriableServerError(GithubException):
     pass
 
 
+class BadGatewayError(RetriableServerError):
+    pass
+
+
 ERROR_CODE_EXCEPTION_MAPPING = {
     301: {
         "raise_exception": MovedPermanentlyError,
@@ -261,7 +265,7 @@ def raise_for_error(resp, source, remaining):
         return None
 
     if error_code == 502:
-        return None
+        raise BadGatewayError(resp.text)
 
     if 500 <= error_code < 600:
         raise RetriableServerError(resp.text)
@@ -391,6 +395,9 @@ def authed_get(source, url, headers={}):
             # wait for limit to reset
             if resp.status_code == 403:
                 rate_throttling(resp)
+            # Copilot stream handles 502 itself (stops instead of retrying)
+            if resp.status_code == 502 and source == COPILOT_USER_METRICS_STREAM:
+                return resp
             # retry
             raise_for_error(resp, source, remaining)
         timer.tags[metrics.Tag.http_status_code] = resp.status_code
@@ -402,7 +409,11 @@ def authed_get(source, url, headers={}):
 
 def authed_get_all_pages(source, url, headers={}):
     while True:
-        r = authed_get(source, url, headers)
+        try:
+            r = authed_get(source, url, headers)
+        except BadGatewayError as e:
+            logger.warning("Stopping stream %s after exhausting retries on 502: %s", source, e)
+            return
         yield r
         if "next" in r.links:
             url = r.links["next"]["url"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes retry/termination behavior for HTTP 502 responses, which can affect whether streams stop early vs retry and thus impact completeness during transient GitHub outages. Also adjusts artifact pagination parameters, which may change the volume of records retrieved per request.
> 
> **Overview**
> **Improves handling of GitHub HTTP 502 responses to avoid infinite/expensive retries.** A new `BadGatewayError` is raised on 502s; the Copilot metrics stream now returns the 502 response (so callers can stop), and `authed_get_all_pages` catches exhausted-502 retries to log and exit the stream.
> 
> **Tweaks Copilot metrics behavior on 502.** When the Copilot report metadata request returns 502, the stream logs a warning and stops rather than continuing.
> 
> **Fixes artifacts pagination query param.** Updates the artifacts list request to use `per_page=100` instead of the incorrect `page_len=100`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c44cafbb439385bd3757974304925fd35fb2d1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->