### PR TITLE
Add commit stats to commit stream

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -27,6 +27,9 @@ def add_insert_timestamp(record):
 session = requests.Session()
 logger = singer.get_logger()
 
+# Cache of commit stats fetched during pr_commits processing, keyed by (repo_path, sha)
+_commit_stats_cache: Dict[Tuple[str, str], Optional[dict]] = {}
+
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300
 
@@ -1787,6 +1790,7 @@ def get_commits_for_pr(pr_number, pr_id, schema, repo_path, state, mdata):
                 commit_details = response.json()
                 commit["files"] = commit_details.get("files")
                 commit["stats"] = commit_details.get("stats")
+                _commit_stats_cache[(repo_path, sha)] = commit["stats"]
                 with singer.Transformer() as transformer:
                     rec = transformer.transform(
                         commit, schema, metadata=metadata.to_map(mdata)
@@ -1928,9 +1932,21 @@ def get_all_commits(schema, repo_path, state, mdata, start_date):
             extraction_time = singer.utils.now()
             for commit in commits:
                 commit["_sdc_repository"] = repo_path
+                sha = commit.get("sha")
                 commit["pull_request_ids"] = get_commit_pull_request_ids(
-                    repo_path, commit.get("sha")
+                    repo_path, sha
                 )
+                if (repo_path, sha) in _commit_stats_cache:
+                    commit["stats"] = _commit_stats_cache[(repo_path, sha)]
+                else:
+                    for detail_response in authed_get_all_pages(
+                        "commit_details",
+                        "https://api.github.com/repos/{}/commits/{}".format(repo_path, sha),
+                    ):
+                        detail = detail_response.json()
+                        commit["stats"] = detail.get("stats")
+                        _commit_stats_cache[(repo_path, sha)] = commit["stats"]
+                        break
                 with singer.Transformer() as transformer:
                     rec = transformer.transform(
                         commit, schema, metadata=metadata.to_map(mdata)

--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -308,6 +308,23 @@
         }
       }
     },
+    "stats": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "additions": {
+          "type": ["null", "integer"]
+        },
+        "deletions": {
+          "type": ["null", "integer"]
+        },
+        "total": {
+          "type": ["null", "integer"]
+        }
+      }
+    },
     "pull_request_ids": {
       "type": [
         "null",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Uncached commits trigger an additional GitHub API request per SHA, which can increase rate-limit pressure; behavior depends on in-process cache and sync order when both commits and pr_commits are selected.
> 
> **Overview**
> The **`commits`** stream now includes a **`stats`** object (`additions`, `deletions`, `total`) from GitHub’s per-commit detail API, with the Singer schema updated to match.
> 
> **`get_all_commits`** loads stats via `repos/{repo}/commits/{sha}` when not already cached. **`get_commits_for_pr`** (`pr_commits`) writes into a module-level **`_commit_stats_cache`** keyed by `(repo_path, sha)` so the same SHA is not re-fetched when both streams run in one sync.
> 
> **Risk note:** Each uncached commit adds an extra API call, which can affect rate limits on large repos; the cache only dedupes within a single process run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb8bad51ba3f755f5cebd810c176d0cc1b2c323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->